### PR TITLE
update build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,9 @@ UpgradeLog*.htm
 
 # FAKE
 .fake/
+
+# .Net Core
+.dotnet/
+
+# Tools
+tools/

--- a/build.fsx
+++ b/build.fsx
@@ -88,6 +88,15 @@ Target "CreateNuget" (fun _ ->
                 AdditionalArgs = ["--include-symbols"]
                 VersionSuffix = versionSuffix
                 OutputPath = outputNuGet })
+
+    DotNetCli.Pack
+        (fun p -> 
+            { p with
+                Project = "./src/TCK/Reactive.Streams.TCK/Reactive.Streams.TCK.csproj"
+                Configuration = configuration
+                AdditionalArgs = ["--include-symbols /p:NuspecFile=Reactive.Streams.TCK.nuspec"]
+                VersionSuffix = versionSuffix
+                OutputPath = outputNuGet })
 )
 
 Target "PublishNuget" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -62,7 +62,8 @@ Target "Build" (fun _ ->
 )
 
 Target "RunTests" (fun _ ->
-    let nunitAssemblies = !! "./src/tck/Reactive.Streams.TCK.Tests/bin/Release/net45/Reactive.Streams.TCK.Tests.dll"
+    let nunitAssemblies = !! "./src/tck/Reactive.Streams.TCK.Tests/bin/Release/net45/Reactive.Streams.TCK.Tests.dll" 
+                          ++ "./src/examples/Reactive.Streams.Example.Unicast.Tests/bin/Release/net45/Reactive.Streams.Example.Unicast.Tests.dll"
 
     NUnit3
         (fun p -> 

--- a/src/tck/Reactive.Streams.TCK/Reactive.Streams.TCK.nuspec
+++ b/src/tck/Reactive.Streams.TCK/Reactive.Streams.TCK.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Reactive.Streams.TCK</id>
+    <version>1.0.0</version>
+    <authors>Reactive Streams</authors>
+    <owners>Reactive Streams</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>http://creativecommons.org/publicdomain/zero/1.0/</licenseUrl>
+    <projectUrl>https://github.com/reactive-streams/reactive-streams-dotnet</projectUrl>
+    <description>Reactive Streams Technology Compatibility Kit</description>
+    <copyright>CC0 1.0 Universal</copyright>
+    <tags>reactive stream</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="Reactive.Streams" version="1.0.0" />
+        <dependency id="NUnit" version="3.6.1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\net45\Reactive.Streams.Example.Unicast.dll" target="lib\net45" />
+    <file src="bin\Release\net45\Reactive.Streams.TCK.dll" target="lib\net45" />
+  </files>
+</package>


### PR DESCRIPTION
The Unicast tests are now included in the test run and the nuspec file is used as a workaround for the TCK nuget package.