### PR TITLE
Upgrade to NUnit 3.12, Add NetCore 3.0 variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,5 @@ UpgradeLog*.htm
 
 # Tools
 tools/
+
+.vs/

--- a/build.ps1
+++ b/build.ps1
@@ -30,11 +30,11 @@ Param(
 )
 
 $FakeVersion = "4.57.4"
-$NUnitVersion = "3.12.0"
+$NUnitVersion = "3.9.0"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
-$NugetVersion = "4.1.0";
+$DotNetVersion = "3.0.100";
+$DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
+$NugetVersion = "5.3.1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 
 # Make sure tools folder exists

--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ Param(
 )
 
 $FakeVersion = "4.57.4"
-$NUnitVersion = "3.6.0"
+$NUnitVersion = "3.12.0"
 $DotNetChannel = "preview";
 $DotNetVersion = "1.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";

--- a/src/api/Reactive.Streams/Reactive.Streams.csproj
+++ b/src/api/Reactive.Streams/Reactive.Streams.csproj
@@ -6,7 +6,7 @@
     <Copyright>CC0 1.0 Universal</Copyright>
     <VersionPrefix>1.0.3</VersionPrefix>
     <Authors>Reactive Streams</Authors>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net45;netcoreapp3.0</TargetFrameworks>
     <PackageTags>reactive;stream</PackageTags>
     <PackageProjectUrl>https://github.com/reactive-streams/reactive-streams-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>http://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>

--- a/src/examples/Reactive.Streams.Example.Unicast.Tests/Reactive.Streams.Example.Unicast.Tests.csproj
+++ b/src/examples/Reactive.Streams.Example.Unicast.Tests/Reactive.Streams.Example.Unicast.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Reactive.Streams.Example.Unicast.Tests</AssemblyName>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
   
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/examples/Reactive.Streams.Example.Unicast/AsyncIterablePublisher.cs
+++ b/src/examples/Reactive.Streams.Example.Unicast/AsyncIterablePublisher.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Reactive.Streams.Example.Unicast
 {
     public class AsyncIterablePublisher<T> : IPublisher<T>
-    { 
+    {
         // These represent the protocol of the `AsyncIterablePublishers` SubscriptionImpls
         private interface ISignal { }
 
@@ -61,7 +62,7 @@ namespace Reactive.Streams.Example.Unicast
 
         private AsyncIterablePublisher(IEnumerable<T> elements, int batchSize)
         {
-            if(elements == null)
+            if (elements == null)
                 throw new ArgumentNullException(nameof(elements));
             if (batchSize < 1)
                 throw new ArgumentNullException(nameof(batchSize), "batchSize must be greater than zero!");
@@ -121,13 +122,13 @@ namespace Reactive.Streams.Example.Unicast
                             if (_inboundSignals.TryDequeue(out signal) && !_cancelled) // to make sure that we follow rule 1.8, 3.6 and 3.7
                             {
                                 // Below we simply unpack the `Signal`s and invoke the corresponding method
-                                if(signal is RequestSignal)
+                                if (signal is RequestSignal)
                                     DoRequest(((RequestSignal)signal).N);
                                 else if (signal == SendSignal.Instance)
                                     DoSend();
-                                else if(signal == CancelSignal.Instance)
+                                else if (signal == CancelSignal.Instance)
                                     DoCancel();
-                                else if(signal == SubscribeSignal.Instance)
+                                else if (signal == SubscribeSignal.Instance)
                                     DoSubscribe();
                             }
                         }
@@ -144,12 +145,12 @@ namespace Reactive.Streams.Example.Unicast
             private void DoRequest(long n)
             {
                 if (n < 1)
-                    TerminateDueTo(new ArgumentException(_subscriber +" violated the Reactive Streams rule 3.9 by requesting a non-positive number of elements"));
+                    TerminateDueTo(new ArgumentException(_subscriber + " violated the Reactive Streams rule 3.9 by requesting a non-positive number of elements"));
                 else if (_demand + n < 1)
                 {
                     // As governed by rule 3.17, when demand overflows `long.MaxValue` we treat the signalled demand as "effectively unbounded"
                     _demand = long.MaxValue;
-                        // Here we protect from the overflow and treat it as "effectively unbounded"
+                    // Here we protect from the overflow and treat it as "effectively unbounded"
                     DoSend(); // Then we proceed with sending data downstream
                 }
                 else
@@ -250,13 +251,13 @@ namespace Reactive.Streams.Example.Unicast
                         try
                         {
                             next = _enumerator.Current;
-                                // We have already checked `MoveNext` when subscribing, so we can fall back to testing -after- `Current` is called.
+                            // We have already checked `MoveNext` when subscribing, so we can fall back to testing -after- `Current` is called.
                             hasNext = _enumerator.MoveNext(); // Need to keep track of End-of-Stream
                         }
                         catch (Exception ex)
                         {
                             TerminateDueTo(ex);
-                                // If `Current` or `MoveNext` throws (they can, since it is user-provided), we need to treat the stream as errored as per rule 1.4
+                            // If `Current` or `MoveNext` throws (they can, since it is user-provided), we need to treat the stream as errored as per rule 1.4
                             return;
                         }
 

--- a/src/examples/Reactive.Streams.Example.Unicast/AtomicBoolean.cs
+++ b/src/examples/Reactive.Streams.Example.Unicast/AtomicBoolean.cs
@@ -30,8 +30,7 @@ namespace Reactive.Streams.Example.Unicast
         {
             get
             {
-                Interlocked.MemoryBarrier();
-                return _value == TrueValue;
+                return Volatile.Read(ref _value) == TrueValue;
             }
             set
             {

--- a/src/examples/Reactive.Streams.Example.Unicast/Reactive.Streams.Example.Unicast.csproj
+++ b/src/examples/Reactive.Streams.Example.Unicast/Reactive.Streams.Example.Unicast.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Reactive.Streams.Example.Unicast</AssemblyName>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net45;netcoreapp3.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/tck/Reactive.Streams.TCK.Tests/Reactive.Streams.TCK.Tests.csproj
+++ b/src/tck/Reactive.Streams.TCK.Tests/Reactive.Streams.TCK.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Reactive.Streams.TCK.Tests</AssemblyName>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
   
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/tck/Reactive.Streams.TCK/PublisherVerification.cs
+++ b/src/tck/Reactive.Streams.TCK/PublisherVerification.cs
@@ -129,7 +129,7 @@ namespace Reactive.Streams.TCK
             ActivePublisherTest(1, true, publisher =>
             {
                 var subscriber = _environment.NewManualSubscriber(publisher);
-                Assert.True(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced no elements");
+                InternalAssertTrue(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced no elements");
                 subscriber.RequestEndOfStream();
             });
         }
@@ -145,20 +145,20 @@ namespace Reactive.Streams.TCK
             ActivePublisherTest(3, true, publisher =>
             {
                 var subscriber = _environment.NewManualSubscriber(publisher);
-                Assert.True(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced no elements");
-                Assert.True(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced only 1 element");
-                Assert.True(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced only 3 element");
+                InternalAssertTrue(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced no elements");
+                InternalAssertTrue(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced only 1 element");
+                InternalAssertTrue(requestNextElementOrEndOfStream(publisher, subscriber).HasValue, $"Publisher {publisher} produced only 3 element");
                 subscriber.RequestEndOfStream();
             });
         }
 
         [Test]
         public void Required_validate_maxElementsFromPublisher()
-            => Assert.True(MaxElementsFromPublisher >= 0, "maxElementsFromPublisher MUST return a number >= 0");
+            => InternalAssertTrue(MaxElementsFromPublisher >= 0, "maxElementsFromPublisher MUST return a number >= 0");
 
         [Test]
         public void Required_validate_boundedDepthOfOnNextAndRequestRecursion()
-            => Assert.True(BoundedDepthOfOnNextAndRequestRecursion >= 1, "boundedDepthOfOnNextAndRequestRecursion must return a number >= 1");
+            => InternalAssertTrue(BoundedDepthOfOnNextAndRequestRecursion >= 1, "boundedDepthOfOnNextAndRequestRecursion must return a number >= 1");
 
 
         ////////////////////// SPEC RULE VERIFICATION ///////////////////////////////
@@ -642,8 +642,8 @@ namespace Reactive.Streams.TCK
                 check2.Add(z2);
                 check2.Add(z3);
 
-                Assert.AreEqual(r, check1, $"Publisher {publisher} did not produce the same element sequence for subscribers 1 and 2");
-                Assert.AreEqual(r, check2, $"Publisher {publisher} did not produce the same element sequence for subscribers 1 and 3");
+                InternalAssertAreEqual(r, check1, $"Publisher {publisher} did not produce the same element sequence for subscribers 1 and 2");
+                InternalAssertAreEqual(r, check2, $"Publisher {publisher} did not produce the same element sequence for subscribers 1 and 3");
             });
 
 
@@ -670,9 +670,17 @@ namespace Reactive.Streams.TCK
                 //       a similar test *with* completion checking is implemented
 
 
-                Assert.AreEqual(received1, received2, "Expected elements to be signaled in the same sequence to 1st and 2nd subscribers");
-                Assert.AreEqual(received2, received3, "Expected elements to be signaled in the same sequence to 2st and 3nd subscribers");
+                InternalAssertAreEqual(received1, received2, "Expected elements to be signaled in the same sequence to 1st and 2nd subscribers");
+                InternalAssertAreEqual(received2, received3, "Expected elements to be signaled in the same sequence to 2st and 3nd subscribers");
             });
+
+        private void InternalAssertAreEqual(object one, object two, string message)
+        {
+            if (!object.Equals(one, two))
+            {
+                throw new AssertionException(message + "\r\nExpected: " + one + "\r\nBut was:  " + two);
+            }
+        }
 
         // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.11
         [Test]
@@ -697,8 +705,8 @@ namespace Reactive.Streams.TCK
                 sub2.ExpectCompletion();
                 sub3.ExpectCompletion();
 
-                Assert.AreEqual(received1, received2, "Expected elements to be signaled in the same sequence to 1st and 2nd subscribers");
-                Assert.AreEqual(received2, received3, "Expected elements to be signaled in the same sequence to 2st and 3nd subscribers");
+                InternalAssertAreEqual(received1, received2, "Expected elements to be signaled in the same sequence to 1st and 2nd subscribers");
+                InternalAssertAreEqual(received2, received3, "Expected elements to be signaled in the same sequence to 2st and 3nd subscribers");
             });
 
         ///////////////////// SUBSCRIPTION TESTS //////////////////////////////////
@@ -965,12 +973,20 @@ namespace Reactive.Streams.TCK
                     }
 
                     // if the Publisher tries to emit more elements than was requested (and/or ignores cancellation) this will throw
-                    Assert.True(onNextSignalled <= totalDemand,
+                    InternalAssertTrue(onNextSignalled <= totalDemand,
                         $"Publisher signalled {onNextSignalled} elements, which is more than the signalled demand: {totalDemand}");
                 } while (stillbeeingSignalled);
             });
 
             _environment.VerifyNoAsyncErrorsNoDelay();
+        }
+
+        private void InternalAssertTrue(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new AssertionException(message);
+            }
         }
 
         // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.13

--- a/src/tck/Reactive.Streams.TCK/Reactive.Streams.TCK.csproj
+++ b/src/tck/Reactive.Streams.TCK/Reactive.Streams.TCK.csproj
@@ -6,7 +6,7 @@
     <Copyright>CC0 1.0 Universal</Copyright>
     <VersionPrefix>1.0.3</VersionPrefix>
     <Authors>Reactive Streams</Authors>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
     <PackageTags>reactive;stream</PackageTags>
     <PackageProjectUrl>https://github.com/reactive-streams/reactive-streams-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>http://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.12" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/tck/Reactive.Streams.TCK/SubscriberBlackboxVerification.cs
+++ b/src/tck/Reactive.Streams.TCK/SubscriberBlackboxVerification.cs
@@ -301,7 +301,7 @@ namespace Reactive.Streams.TCK
                     gotNpe = true;
                 }
 
-                Assert.True(gotNpe, "OnSubscribe(null) did not throw ArgumentNullException");
+                InternalAssertTrue(gotNpe, "OnSubscribe(null) did not throw ArgumentNullException");
                 Environment.VerifyNoAsyncErrorsNoDelay();
             });
 
@@ -327,7 +327,7 @@ namespace Reactive.Streams.TCK
                     gotNpe = true;
                 }
 
-                Assert.True(gotNpe, "OnNext(null) did not throw ArgumentNullException");
+                InternalAssertTrue(gotNpe, "OnNext(null) did not throw ArgumentNullException");
                 Environment.VerifyNoAsyncErrorsNoDelay();
             });
 
@@ -349,9 +349,17 @@ namespace Reactive.Streams.TCK
                     gotNpe = true;
                 }
 
-                Assert.True(gotNpe, "OnError(null) did not throw ArgumentNullException");
+                InternalAssertTrue(gotNpe, "OnError(null) did not throw ArgumentNullException");
                 Environment.VerifyNoAsyncErrorsNoDelay();
             });
+
+        private void InternalAssertTrue(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new AssertionException(message);
+            }
+        }
 
         private sealed class Spec213DummySubscription : ISubscription
         {

--- a/src/tck/Reactive.Streams.TCK/TestEnvironment.cs
+++ b/src/tck/Reactive.Streams.TCK/TestEnvironment.cs
@@ -145,14 +145,7 @@ namespace Reactive.Streams.TCK
         /// </summary>
         public void Flop(string message)
         {
-            try
-            {
-                Assert.Fail(message);
-            }
-            catch (Exception ex)
-            {
-                AsyncErrors.Enqueue(ex);
-            }
+            AsyncErrors.Enqueue(new AssertionException(message));
         }
 
         /// <summary>
@@ -169,14 +162,7 @@ namespace Reactive.Streams.TCK
         /// </summary>
         public void Flop(Exception exception, string message)
         {
-            try
-            {
-                Assert.Fail(message, exception);
-            }
-            catch (Exception)
-            {
-                AsyncErrors.Enqueue(exception);
-            }
+            AsyncErrors.Enqueue(exception);
         }
 
         /// <summary>
@@ -193,14 +179,7 @@ namespace Reactive.Streams.TCK
         /// </summary>
         public void Flop(Exception exception)
         {
-            try
-            {
-                Assert.Fail(exception.Message, exception);
-            }
-            catch (Exception)
-            {
-                AsyncErrors.Enqueue(exception);
-            }
+            AsyncErrors.Enqueue(exception);
         }
 
         /// <summary>
@@ -217,17 +196,9 @@ namespace Reactive.Streams.TCK
         /// </summary>
         public T FlopAndFail<T>(string message)
         {
-            try
-            {
-                Assert.Fail(message);
-            }
-            catch (Exception ex)
-            {
-                AsyncErrors.Enqueue(ex);
-                Assert.Fail(message, ex);
-            }
-
-            return default(T); // unreachable, the previous block will always exit by throwing
+            var ae = new AssertionException(message);
+            AsyncErrors.Enqueue(ae);
+            throw new AssertionException(message, ae);
         }
 
 
@@ -307,7 +278,7 @@ namespace Reactive.Streams.TCK
                 if (exception != null)
                     throw exception;
 
-                Assert.Fail($"Async error during test execution: {error.Message}", error);
+                throw new AssertionException($"Async error during test execution: {error.Message}", error);
             }
         }
 
@@ -738,8 +709,17 @@ namespace Reactive.Streams.TCK
     public class Promise<T>
     {
         private readonly TestEnvironment _environment;
-        private readonly BlockingCollection<T> _blockingCollection = new BlockingCollection<T>();
-        private Option<T> _value;
+        private readonly CountdownEvent cde = new CountdownEvent(1);
+        private PromiseNode _node;
+
+        private sealed class PromiseNode
+        {
+            internal readonly T value;
+            internal PromiseNode(T value)
+            {
+                this.value = value;
+            }
+        }
 
         public Promise(TestEnvironment environment)
         {
@@ -757,20 +737,33 @@ namespace Reactive.Streams.TCK
         {
             get
             {
-                if (IsCompleted())
-                    return _value.Value;
+                var n = Volatile.Read(ref _node);
+                if (n != null)
+                    return n.value;
                 
                 _environment.Flop("Cannot access promise value before completion");
                 return default(T);
             }
         }
 
-        public bool IsCompleted() => _value.HasValue;
-
+        public bool IsCompleted()
+        {
+            return Volatile.Read(ref _node) != null;
+        }
         /// <summary>
         /// Allows using ExpectCompletion to await for completion of the value and complete it _then_
         /// </summary>
-        public void Complete(T value) => _blockingCollection.Add(value);
+        public void Complete(T value)
+        {
+            if (Interlocked.CompareExchange(ref _node, new PromiseNode(value), null) == null)
+            {
+                cde.Signal();
+            }
+            else
+            {
+                _environment.Flop("Already completed");
+            }
+        }
 
         /// <summary>
         /// Completes the promise right away, it is not possible to ExpectCompletion on a Promise completed this way
@@ -778,18 +771,19 @@ namespace Reactive.Streams.TCK
         public void CompleteImmediatly(T value)
         {
             Complete(value); // complete!
-            _value = value; // immediatly!
         }
 
         public void ExpectCompletion(long timeoutMilliseconds, string errorMessage)
         {
             if (!IsCompleted())
             {
-                T value;
-                if (!_blockingCollection.TryTake(out value, TimeSpan.FromMilliseconds(timeoutMilliseconds)))
-                    _environment.Flop($"{errorMessage} within {timeoutMilliseconds} ms");
-                else
-                    _value = value;
+                if (!cde.Wait(TimeSpan.FromMilliseconds(timeoutMilliseconds)))
+                {
+                    if (!IsCompleted())
+                    {
+                        _environment.Flop($"{errorMessage} within {timeoutMilliseconds} ms");
+                    }
+                }
             }
         }
     }
@@ -883,7 +877,10 @@ namespace Reactive.Streams.TCK
 
         public E ExpectError<E>(long timeoutMilliseconds, string errorMessage) where E : Exception
         {
-            Thread.Sleep(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+            if (_environment.AsyncErrors.IsEmpty)
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+            }
 
             if (_environment.AsyncErrors.IsEmpty)
                 return _environment.FlopAndFail<E>($"{errorMessage} within {timeoutMilliseconds} ms");


### PR DESCRIPTION
Looks like there was a breaking change between NUnit 3.6 and 3.12 (latest as of now) so my [project](https://github.com/akarnokd/Reactive4.NET) used to verify the TCK stopped running unit tests alltogheter. This PR also adds NETCoreApp3.0 as an output framework. I don't know how that will end up in the NuGet release though.

For one, upgrading to NUnit 3.12 dependency explicitly should resolve the problem. Unfortunately, when this is done, the Reactive.Streams.TCK.Tests start to fail with awkward errors on a known to be correct implementation of `RangePublisherTest`:

```
Required_spec309_requestNegativeNumberMustSignalIllegalArgumentException
  No source available
   Duration: 584 ms

  Message: 
    Unexpected Subscriber.OnError(System.ArgumentException: §3.9 violated)
  Stack Trace: 
    TestEnvironment.Flop(Exception exception, String message) line 174
    TestSubscriber`1.OnError(Exception cause) line 612
    ManualSubscriberWithSubscriptionSupport`1.OnError(Exception cause) line 560
    RangeSubscription.Request(Int64 n) line 123
    ManualSubscriber`1.Request(Int64 elements) line 370
    PublisherVerification`1.<Required_spec309_requestNegativeNumberMustSignalIllegalArgumentException>b__56_0(IPublisher`1 publisher) line 914
    PublisherVerification`1.ActivePublisherTest(Int64 elements, Boolean completionSignalRequired, Action`1 run) line 1125
    PublisherVerification`1.Required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() line 910
```

`EmptyLazyPublisherTest`:

```
 Optional_spec105_emptyStreamMustTerminateBySignallingOnComplete
  No source available
   Duration: 1 sec

  Message: 
    Multiple failures or warnings in test:
      1) Subscriber.OnComplete() called before Subscriber.OnSubscribe()
      2) Did not receive expected stream completion within 500 ms
    
  Stack Trace: 
    TestEnvironment.Flop(String message) line 150
    ManualSubscriberWithSubscriptionSupport`1.OnComplete() line 544
    SubscriptionImplementation.DoSubscribe() line 212
    <.ctor>b__9_0() line 131
    Task.InnerInvoke()
    <.cctor>b__274_0(Object obj)
    TestEnvironment.Flop(String message) line 150
    Receptacle`1.ExpectCompletion(Int64 timeoutMilliseconds, String errorMessage) line 878
    ManualSubscriber`1.ExpectCompletion(Int64 timeoutMilliseconds, String errorMessage) line 486
    ManualSubscriber`1.ExpectCompletion(Int64 timeoutMilliseconds) line 480
    ManualSubscriber`1.ExpectCompletion() line 477
    PublisherVerification`1.<Optional_spec105_emptyStreamMustTerminateBySignallingOnComplete>b__30_0(IPublisher`1 publisher) line 414
    PublisherVerification`1.PotentiallyPendingTest(IPublisher`1 publisher, Action`1 run, String message) line 1180
    PublisherVerification`1.PotentiallyPendingTest(IPublisher`1 publisher, Action`1 run) line 1175
    PublisherVerification`1.OptionalActivePublisherTest(Int64 elements, Boolean completionSignalRequired, Action`1 run) line 1149
    PublisherVerification`1.Optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() line 410
```